### PR TITLE
Fix issues with builder script clearbuilds function and fixes for Ted on Linux.

### DIFF
--- a/src/builder.ps1
+++ b/src/builder.ps1
@@ -24,7 +24,7 @@ Param(
     [switch]$clearbuilds = $false
 )
 
-[string]$SCRIPT_VER = "1.2.0"
+[string]$SCRIPT_VER = "1.2.1"
 
 Clear-Host
 

--- a/src/builder.sh
+++ b/src/builder.sh
@@ -3,7 +3,7 @@
 
 # Get this script directory
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-SCRIPT_VER="1.2.0"
+SCRIPT_VER="1.2.1"
 
 TRANSCC_EXE=0                           # Flag to indicate that transcc has been built.
 BULDER_SCRIPT=1                         # Flag that should be used to indicate to other scripts that they should be part of the buildr script. See freedesktop.sh

--- a/src/builders/bash/tools.sh
+++ b/src/builders/bash/tools.sh
@@ -218,7 +218,7 @@ do_clearbuilds(){
     do_info "CLEARING OUT PREVIOUS BUILDS"
 
     # Remove all macOS applications. Ted and CServer
-    find "$BIN" -type d -name '*.app' -exec rm -rf "{}" \;
+	find "$BIN" -type d -name '*.app' -prune -exec rm -rf "{}" \;
 
     # Remove transcc linux, winnt and macos
     find "$BIN" -type f -name 'transcc_*' -delete
@@ -226,11 +226,11 @@ do_clearbuilds(){
     # Remove the launchers linux, winnt and macos
     find "$ROOT" -type f -name 'Cerberus.exe' -delete
     find "$ROOT" -type f -name 'Cerberus' -delete
-    find "$ROOT" -type d -name 'Cerberus.app' -exec rm -rf "{}" \;
+    find "$ROOT" -type d -name 'Cerberus.app' -prune -exec rm -rf "{}" \;
     find "$ROOT" -type f -name '*.desktop' -delete
   
     # Remove CServer linux and winnt
-    find "$BIN" -type f -name 'Cerberus.*' -delete
+    find "$BIN" -type f -name 'cserver_*' -delete
 
     # Remove makedocs linux, winnt and macos
     find "$BIN" -type f -name 'makedocs_*' -delete
@@ -240,10 +240,12 @@ do_clearbuilds(){
     find "$BIN" -type f -name 'Ted' -delete
 
     # Remove Qt Linux support files and directories
-    find "$BIN" -type d -name 'lib*' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'plugins' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'resources' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'translations' -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'lib*' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'iconengines' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'imageformats' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'plugins' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'resources' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'translations' -prune -exec rm -rf "{}" \;
 
     # Remove Qt WinNT support files and directories
     find "$BIN" -type f -name 'qt.conf' -delete
@@ -252,6 +254,6 @@ do_clearbuilds(){
     find "$BIN" -type f -name '*.ilk' -delete
     find "$BIN" -type f -name '*.pdb' -delete
     find "$BIN" -type f -name 'openal32_*' -delete
-    find "$BIN" -type d -name 'platforms' -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'platforms' -prune -exec rm -rf "{}" \;
 
 }

--- a/src/builders/pwshell/tools.ps1
+++ b/src/builders/pwshell/tools.ps1
@@ -249,7 +249,9 @@ function do_clearbuilds() {
     If(Test-Path("$BIN\Ted.exe")) { Remove-Item "$BIN\Ted.exe" -Force }
 
     # Remove Qt Linux support files and directories.
-    Remove-Item "$BIN\lib*" -Recurse -Force
+	Remove-Item "$BIN\lib*" -Recurse -Force
+	if(Test-Path("$BIN\imageformats")) { Remove-Item "$BIN\imageformats" -Recurse -Force }
+	if(Test-Path("$BIN\iconengines")) { Remove-Item "$BIN\iconengines" -Recurse -Force }
     if(Test-Path("$BIN\plugins")) { Remove-Item "$BIN\plugins" -Recurse -Force }
     if(Test-Path("$BIN\resources")) { Remove-Item "$BIN\resources" -Recurse -Force }
     if(Test-Path("$BIN\translations")) { Remove-Item "$BIN\translations" -Recurse -Force }

--- a/src/launcher/launcher.cxs
+++ b/src/launcher/launcher.cxs
@@ -1,10 +1,10 @@
 
 #If HOST<>"linux"
-#Error "Host<>linux"
+#Error "The launcher can only be compiled on a Linux host"
 #Endif
 
 #If TARGET<>"stdcpp"
-#Error "Target<>stdcpp"
+#Error "The launcher can only be built with the stdcpp target."
 #Endif
 
 Import brl.process
@@ -21,18 +21,13 @@ Function Main()
 	Next
 	
 	Local dir:=ExtractDir( AppPath() )
-	
-#If HOST="macos"
 
-	Local cmd:=dir+"/bin/Ted.app"
-	If args cmd="open -n "+cmd+" --args"+args Else cmd="open "+cmd
-	Execute cmd
-	Sleep 100
-	
-#Else If HOST="linux"
-
-	Execute dir+"/bin/Ted"+args+" >/dev/null 2>/dev/null &"
-
-#Endif
-
+	' Ensure that the IDE will pick up the Qt libraries.
+	If GetEnv( "LD_LIBRARY_PATH" ).Contains( dir+"/bin/lib:" )
+		Print "LD_LIBRARY_PATH ALREADY CONTAINS: "+dir+"/bin/lib"
+		Execute  dir+"/bin/Ted"+args+" >/dev/null 2>/dev/null &"
+	Else
+		Print "ADDED "+dir+"/bin/lib to LD_LIBRARY_PATH"
+		Execute  "export LD_LIBRARY_PATH="+dir+"/bin/lib:$LD_LIBRARY_PATH && "+dir+"/bin/Ted"+args+" >/dev/null 2>/dev/null &"
+	Endif
 End


### PR DESCRIPTION
Builder scripts function to clean up previous builds:
Added a fix to the builder script that cleans up previous builds on Linux & macOS. It should now no longer say that it cannot find files, even though is does. Plus it will now remove cserver on Linux & macOS.
Added removal of iconengines and imageformats directories.

Launcher:
Updated the launcher for Linux to ensure that it will locate the Qt libraries when they are distributed with CX.

Ted project file:
Changed how information is displayed when qmake is run.
Added the deployment of iconengine and imageformats on Linux builds to fix an issue where the project browser wasn't   
displaying file icons correctly.