### PR TITLE
Builder scripts tool build

### DIFF
--- a/src/builders/bash/common.sh
+++ b/src/builders/bash/common.sh
@@ -99,10 +99,21 @@ do_build_result(){
     [ $EXITCODE -eq 0 ] && {
         do_success "BUILD SUCCESSFUL"
         echo "";
-        } || {
+    } || {
         do_error "BUILD FAILED"
         echo "";
     }
+}
+
+# Function to get the Cerberus X version from the VERSIONS.TXT file
+do_cx_vers() {
+    while IFS= read -r line; do
+        [ "${line:0:1}" = "*" ] && {
+            CX_VERSION=$(echo "$line" | sed 's/[* ]//g')
+            break;
+        }
+    done < "$CERBERUS_ROOT_DIR/VERSIONS.TXT"
+    echo $CX_VERSION
 }
 
 # Function to execute transcc

--- a/src/builders/bash/deploy.sh
+++ b/src/builders/bash/deploy.sh
@@ -110,12 +110,7 @@ do_deploy(){
     }
     
     # Get the version from the Cerberus versions text file.
-    while IFS= read -r line; do
-        [ "${line:0:1}" = "*" ] && {
-            CX_VERSION=$(echo "$line" | sed 's/[* ]//g')
-            break;
-        }
-    done < "$CX_DEPLOY_TARGET/VERSIONS.TXT"
+    CX_VERSION=$(do_cx_vers)
 
     ARCHIVE_CMD=()
 

--- a/src/builders/bash/tools.sh
+++ b/src/builders/bash/tools.sh
@@ -4,9 +4,9 @@
 # THE SCRIPT IS PART OF THE CERBERUS X BUILER TOOL.
 
 # Function to build transcc
-do_transcc(){
+do_boot(){
     EXITCODE=0
-    do_info "BUILDING TRANSCC WITH $COMPILER"
+    do_info "BUILDING BOOT TRANSCC WITH $COMPILER"
     
     # Check for an exisiting transcc
     [ -f "$BIN/transcc_$HOST" ] && { rm -f "$BIN/transcc_$HOST"; }
@@ -44,6 +44,20 @@ do_transcc(){
     do_build_result
     
     return $EXITCODE
+}
+
+do_transcc() {
+    EXITCODE=0
+    do_info "BUILDING TransCC from transcc.cxs"
+    local build_dir="$SRC/transcc/transcc.build$(do_cx_vers)/cpptool"
+    
+    execute "$BIN/transcc_$HOST -target=C++_Tool -clean -config=release +CPP_GC_MODE=0 +CC_OUTPUT_NAME=transcc_$HOST $SRC/transcc/transcc.cxs"
+    [ $EXITCODE -eq 0 ] && {
+        [ -f "$BIN/transcc_$HOST" ] && { rm -f "$BIN/transcc_$HOST"; }
+        mv "$build_dir/transcc_$HOST" "$BIN/transcc_$HOST";
+    }
+
+    return $EXITCODE;
 }
 
 # Function to build CServer
@@ -181,7 +195,7 @@ do_freedesktop(){
 do_all(){
     do_header "\n====== BUILDING ALL TOOLS ======"
     do_info "BUILDING TransCC"
-    do_transcc;
+    do_boot;
     [ $EXITCODE -eq 0 ] && {
         do_info "BUILDING CServer"
         do_cserver;
@@ -218,7 +232,7 @@ do_clearbuilds(){
     do_info "CLEARING OUT PREVIOUS BUILDS"
 
     # Remove all macOS applications. Ted and CServer
-    find "$BIN" -type d -name '*.app' -exec rm -rf "{}" \;
+    find "$BIN" -type d -name '*.app' -prune -exec rm -rf "{}" \;
 
     # Remove transcc linux, winnt and macos
     find "$BIN" -type f -name 'transcc_*' -delete
@@ -226,11 +240,11 @@ do_clearbuilds(){
     # Remove the launchers linux, winnt and macos
     find "$ROOT" -type f -name 'Cerberus.exe' -delete
     find "$ROOT" -type f -name 'Cerberus' -delete
-    find "$ROOT" -type d -name 'Cerberus.app' -exec rm -rf "{}" \;
+    find "$ROOT" -type d -name 'Cerberus.app' -prune -exec rm -rf "{}" \;
     find "$ROOT" -type f -name '*.desktop' -delete
   
     # Remove CServer linux and winnt
-    find "$BIN" -type f -name 'Cerberus.*' -delete
+    find "$BIN" -type f -name 'cserver_*' -delete
 
     # Remove makedocs linux, winnt and macos
     find "$BIN" -type f -name 'makedocs_*' -delete
@@ -240,10 +254,10 @@ do_clearbuilds(){
     find "$BIN" -type f -name 'Ted' -delete
 
     # Remove Qt Linux support files and directories
-    find "$BIN" -type d -name 'lib*' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'plugins' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'resources' -exec rm -rf "{}" \;
-    find "$BIN" -type d -name 'translations' -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'lib*' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'plugins' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'resources' -prune -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'translations' -prune -exec rm -rf "{}" \;
 
     # Remove Qt WinNT support files and directories
     find "$BIN" -type f -name 'qt.conf' -delete
@@ -252,6 +266,6 @@ do_clearbuilds(){
     find "$BIN" -type f -name '*.ilk' -delete
     find "$BIN" -type f -name '*.pdb' -delete
     find "$BIN" -type f -name 'openal32_*' -delete
-    find "$BIN" -type d -name 'platforms' -exec rm -rf "{}" \;
+    find "$BIN" -type d -name 'platforms' -prune -exec rm -rf "{}" \;
 
 }

--- a/src/builders/pwshell/common.ps1
+++ b/src/builders/pwshell/common.ps1
@@ -93,3 +93,14 @@ function transcc([string]$_name, [string]$_target, [string]$_srcfile, [string]$_
         return
     }
 }
+
+# Function to get the Cerberus X version from the VERSIONS.TXT file
+function do_cx_vers() {
+    # Get what should be the first line in the VERSION.TXT file to retrieve the version number.
+    [string]$cx_version = $(Get-Content "$ROOT\VERSIONS.TXT") | ForEach-Object {
+        if($_.ToString().Substring(0,1)) {
+           $_.ToString() -Replace '[*v ]', ''
+        }
+    } | Select-Object -First 1
+    return $cx_version
+}

--- a/src/builders/pwshell/deploy.ps1
+++ b/src/builders/pwshell/deploy.ps1
@@ -87,11 +87,7 @@ Function do_deploy() {
     }
 
     # Get what should be the first line in the VERSION.TXT file to retrieve the version number.
-    [string]$cx_version = $(Get-Content "$cx_deploy_target\VERSIONS.TXT") | ForEach-Object {
-        if($_.ToString().Substring(0,1)) {
-           $_.ToString() -Replace '[*v ]', ''
-        }
-    } | Select-Object -First 1
+    [string]$cx_version = $(do_cx_vers)
     
     # Clear out any old compressed files and recompress.
     if (Test-Path("$cx_deploy_root\Cerberus_$cx_version-$buildtype-qt$qtkit-winnt.zip")) { Remove-Item -Force "$cx_deploy_root\Cerberus_$cx_version-$buildtype-qt$qtkit-winnt.zip" }

--- a/src/docs/BUILDING_LINUX.txt
+++ b/src/docs/BUILDING_LINUX.txt
@@ -67,6 +67,13 @@ The optional arguments to pass to the builder.sh script for the official Qt Inst
 -d or --deploy with the full path to where Cerberus will be built and an archive created. NOTE: This requires that git is installed and is only available in menu mode.
 -a or --archiver with the archiver to use. NOTE: This currently only supports tar.
 -g or --gcc to set the version of GCC to use for the build. If the version specified is not found, then the default it to use the system default.
+-t or --tool with one of the following to build that tool:
+        boot        - Builds the main pre compiled source file.
+        transcc     - Builds the main transcc source file.
+        makedocs    - Builds the document creation tool.
+        launcher    - Builds the Cerberus X IDE launcher.
+        cserver     - Builds the mini cerberus html server.
+        ted         - Builds the IDE Ted.
 --clearbuilds to remove all built files and exit. This also removes those for other systems leaving a clean git repository.
 -h or --help to shows help info.
 

--- a/src/docs/BUILDING_MACOS.txt
+++ b/src/docs/BUILDING_MACOS.txt
@@ -42,7 +42,14 @@ The optional arguments to pass to the builder.sh script for the official Qt Inst
 -k or --qtkit with the dot version number for a specific Qt SDK.
 -m or --showmenu will run the script in menu mode.
 -d or --deploy with the full path to where Cerberus will be built and an archive created. NOTE: This requires that git is installed and is only available in menu mode.
--a or --archiver with the archiver to use. The default is to use hdiutil for generating a dmg file.
+-a or --archiver with the archiver to use. NOTE: Currently unused.
+-t or --tool with one of the following to build that tool:
+        boot        - Builds the main pre compiled source file.
+        transcc     - Builds the main transcc source file.
+        makedocs    - Builds the document creation tool.
+        launcher    - Builds the Cerberus X IDE launcher.
+        cserver     - Builds the mini cerberus html server.
+        ted         - Builds the IDE Ted.
 --clearbuilds to remove all built files and exit. This also removes those for other systems leaving a clean git repository.
 -h or --help to shows help info.
 

--- a/src/docs/BUILDING_WINNT.txt
+++ b/src/docs/BUILDING_WINNT.txt
@@ -56,6 +56,13 @@ The optional arguments to pass to the builder.ps1 script are:
 -b or -msbuild will use msbuild to build all tools. Requires that Visual Studio be installed.
 -s or -stdout is used for viewing output of commands after they have completed. Useful for checking build output.
 -d or -deploy with the full path to where Cerberus will be built and an archive created. NOTE: This requires that git is installed and is only available in menu mode.
+-t or -tool with one of the following to build that tool:
+        boot        - Builds the main pre compiled source file.
+        transcc     - Builds the main transcc source file.
+        makedocs    - Builds the document creation tool.
+        launcher    - Builds the Cerberus X IDE launcher.
+        cserver     - Builds the mini cerberus html server.
+        ted         - Builds the IDE Ted.
 --clearbuilds to remove all built files and exit. This also removes those for other systems leaving a clean git repository.
 -h or -help to shows help info.
 


### PR DESCRIPTION
Added a way to build individual tools from the command line. This now adds an extra build options to build either transcc from the C++ file, or the transcc.cxs file.

Fixed an issue where the clearbuilds option wasn't removing cserver on Linux and macOS.