### PR TITLE
ChangeDir fix to brl.process

### DIFF
--- a/modules/brl/process.cxs
+++ b/modules/brl/process.cxs
@@ -93,8 +93,8 @@ Function CurrentDir:String()
 	Return BBProcess.CurrentDir()
 End
 
-Function ChangeDir:Void( dir:String )
-	BBProcess.ChangeDir dir
+Function ChangeDir:int( dir:String )
+	Return BBProcess.ChangeDir( dir )
 End
 
 Function Execute:Int( cmd:String )


### PR DESCRIPTION
Found this bug while working on creating an new os module.
The documentation is correct for this function, as is the c++ and Cerberus class signature. But the wrapper to the Ceberus class signature is wrong. It show it as returning a void, when it should be returning an integer.