### PR TITLE
Change config tags

### DIFF
--- a/modules/trans/config.cxs
+++ b/modules/trans/config.cxs
@@ -17,6 +17,8 @@ Global ENV_TARGET$
 Global ENV_MODPATH$
 Global ENV_SAFEMODE
 Global ENV_CUSTOMBUILDSCRIPT$
+Global ENV_PROJECTDIRECTORY$
+Global ENV_CERBERUSLIBSDIR$
 
 Private
 
@@ -148,6 +150,9 @@ Function EvalConfigTags$( cfg$ )
 		
 		Local key:=cfg[i+2..e]
 		Local val:=_cfgScope.vars.Get( key )
+
+		' If no value is returned from a stored config, then try the systems environment variables.
+		If val="" val=GetEnv( key )
 		
 		cfg=cfg[..i]+val+cfg[e+1..]
 		i+=val.Length

--- a/src/transcc/builder.cxs
+++ b/src/transcc/builder.cxs
@@ -55,6 +55,8 @@ Class Builder
 		ENV_TARGET=tcc.target.system
 		ENV_LANG=tcc.target.lang
 		ENV_CUSTOMBUILDSCRIPT=tcc.target.buildscript
+		ENV_PROJECTDIRECTORY=ExtractDir( tcc.opt_srcpath )
+		ENV_CERBERUSLIBSDIR=tcc.cerberusdir+"/libs"
 			
 		Self.Begin
 
@@ -68,6 +70,8 @@ Class Builder
 		SetConfigVar "TARGET",ENV_TARGET
 		SetConfigVar "CONFIG",ENV_CONFIG
 		SetConfigVar "SAFEMODE",ENV_SAFEMODE
+		SetConfigVar "PROJECTDIR",ENV_PROJECTDIRECTORY
+		SetConfigVar "CXLIBSDIR",ENV_CERBERUSLIBSDIR
 		'SetConfigVar "CUSTOMBUILDSCRIPT",ENV_CUSTOMBUILDSCRIPT
 		
 		app=ParseApp( tcc.opt_srcpath )

--- a/src/transcc/builders/stdcpp.cxs
+++ b/src/transcc/builders/stdcpp.cxs
@@ -87,7 +87,7 @@ Class StdcppBuilder Extends Builder
 		' Set the output file name and path.
 		' If there isn't an output path, then use the current directory.
 		' Else check the path passed and expand any environment variables.
-		If outpath="" outpath=CurrentDir() Else outpath=RealPath( ExpandEnv( outpath ) )
+		If outpath="" outpath=CurrentDir() Else outpath=RealPath( outpath )
 		If out="" out="main_"+HostOS
 		
 		' Set options for build configuration.
@@ -169,7 +169,7 @@ Class StdcppBuilder Extends Builder
 		' Set the output file name and path.
 		' If there isn't an output path, then use the current directory.
 		' Else check the path passed and expand any environment variables.
-		If outpath="" outpath=CurrentDir() Else outpath=RealPath( ExpandEnv( outpath ) )
+		If outpath="" outpath=CurrentDir() Else outpath=RealPath( outpath )
 		If out="" out="main_"+HostOS
 		
 		' If used, override the CC_OPTS, CC_LIBS, CC_LDOPTS.
@@ -218,7 +218,7 @@ Class StdcppBuilder Extends Builder
 		' Set the output file name and path.
 		' If there isn't an output path, then use the current directory.
 		' Else check the path passed and expand any environment variables.
-		If outpath="" outpath=CurrentDir() Else outpath=RealPath( ExpandEnv( outpath ) )
+		If outpath="" outpath=CurrentDir() Else outpath=RealPath( outpath )
 		If out="" out="main_"+HostOS
 		
 		' If used, override the CC_OPTS, CC_LIBS, CC_LDOPTS.

--- a/src/transcc/transcc.build/cpptool/main.cpp
+++ b/src/transcc/transcc.build/cpptool/main.cpp
@@ -12,7 +12,7 @@
 #define CFG_CONFIG release
 #define CFG_CPP_DOUBLE_PRECISION_FLOATS 1
 #define CFG_CPP_GC_MODE 1
-#define CFG_HOST winnt
+#define CFG_HOST linux
 #define CFG_LANG cpp
 #define CFG_MODPATH 
 #define CFG_RELEASE 1
@@ -17747,6 +17747,8 @@ class c_NodeEnumerator2 : public Object{
 extern String bb_config_ENV_HOST;
 extern String bb_config_ENV_CONFIG;
 extern String bb_config_ENV_TARGET;
+extern String bb_config_ENV_PROJECTDIRECTORY;
+extern String bb_config_ENV_CERBERUSLIBSDIR;
 String bb_os_StripAll(String);
 c_AppDecl* bb_parser_ParseApp(String);
 class c_Reflector : public Object{
@@ -18165,7 +18167,6 @@ class c_DataBuffer : public BBDataBuffer{
 int bb_builder_GetInfo_PNG(String);
 int bb_builder_GetInfo_JPG(String);
 int bb_builder_GetInfo_GIF(String);
-String bb_transcc_ExpandEnv(String);
 int bb_transcc_CreateDirs(String,String);
 class c_CsTranslator : public c_CTranslator{
 	public:
@@ -18528,26 +18529,26 @@ void c_TransCC::p_ParseArgs(){
 			t_arg=t_arg.Slice(0,t_j);
 		}
 		if(t_j==-1){
-			String t_3=t_arg.ToLower();
-			if(t_3==String(L"-safe",5)){
+			String t_2=t_arg.ToLower();
+			if(t_2==String(L"-safe",5)){
 				m_opt_safe=true;
 			}else{
-				if(t_3==String(L"-clean",6)){
+				if(t_2==String(L"-clean",6)){
 					m_opt_clean=true;
 				}else{
-					if(t_3==String(L"-check",6)){
+					if(t_2==String(L"-check",6)){
 						m_opt_check=true;
 					}else{
-						if(t_3==String(L"-update",7)){
+						if(t_2==String(L"-update",7)){
 							m_opt_check=true;
 							m_opt_update=true;
 						}else{
-							if(t_3==String(L"-build",6)){
+							if(t_2==String(L"-build",6)){
 								m_opt_check=true;
 								m_opt_update=true;
 								m_opt_build=true;
 							}else{
-								if(t_3==String(L"-run",4)){
+								if(t_2==String(L"-run",4)){
 									m_opt_check=true;
 									m_opt_update=true;
 									m_opt_build=true;
@@ -18562,26 +18563,26 @@ void c_TransCC::p_ParseArgs(){
 			}
 		}else{
 			if(t_arg.StartsWith(String(L"-",1))){
-				String t_4=t_arg.ToLower();
-				if(t_4==String(L"-cfgfile",8)){
+				String t_3=t_arg.ToLower();
+				if(t_3==String(L"-cfgfile",8)){
 					m_opt_cfgfile=t_rhs;
 				}else{
-					if(t_4==String(L"-output",7)){
+					if(t_3==String(L"-output",7)){
 						m_opt_output=t_rhs;
 					}else{
-						if(t_4==String(L"-config",7)){
+						if(t_3==String(L"-config",7)){
 							m_opt_config=t_rhs.ToLower();
 						}else{
-							if(t_4==String(L"-target",7)){
+							if(t_3==String(L"-target",7)){
 								m_opt_target=t_rhs;
 							}else{
-								if(t_4==String(L"-modpath",8)){
+								if(t_3==String(L"-modpath",8)){
 									m_opt_modpath=t_rhs;
 								}else{
-									if(t_4==String(L"-targetpath",11)){
+									if(t_3==String(L"-targetpath",11)){
 										m_opt_targetpath=t_rhs;
 									}else{
-										if(t_4==String(L"-builddir",9)){
+										if(t_3==String(L"-builddir",9)){
 											m_opt_builddir=t_rhs;
 										}else{
 											bb_transcc_Die(String(L"Unrecognized command line option: ",34)+t_arg);
@@ -18633,66 +18634,66 @@ void c_TransCC::p_LoadConfig(){
 		while(t_path.EndsWith(String(L"/",1)) || t_path.EndsWith(String(L"\\",1))){
 			t_path=t_path.Slice(0,-1);
 		}
-		String t_5=t_lhs;
-		if(t_5==String(L"MODPATH",7)){
+		String t_4=t_lhs;
+		if(t_4==String(L"MODPATH",7)){
 			if(!((m_opt_modpath).Length()!=0)){
 				m_opt_modpath=t_path;
 			}
 		}else{
-			if(t_5==String(L"TARGETPATH",10)){
+			if(t_4==String(L"TARGETPATH",10)){
 				if(!((m_opt_targetpath).Length()!=0)){
 					m_opt_targetpath=t_path;
 				}
 			}else{
-				if(t_5==String(L"ANDROID_PATH",12)){
+				if(t_4==String(L"ANDROID_PATH",12)){
 					if(!((m_ANDROID_PATH).Length()!=0) && FileType(t_path)==2){
 						m_ANDROID_PATH=t_path;
 					}
 				}else{
-					if(t_5==String(L"ANDROID_NDK_PATH",16)){
+					if(t_4==String(L"ANDROID_NDK_PATH",16)){
 						if(!((m_ANDROID_NDK_PATH).Length()!=0) && FileType(t_path)==2){
 							m_ANDROID_NDK_PATH=t_path;
 						}
 					}else{
-						if(t_5==String(L"JDK_PATH",8)){
+						if(t_4==String(L"JDK_PATH",8)){
 							if(!((m_JDK_PATH).Length()!=0) && FileType(t_path)==2){
 								m_JDK_PATH=t_path;
 							}
 						}else{
-							if(t_5==String(L"ANT_PATH",8)){
+							if(t_4==String(L"ANT_PATH",8)){
 								if(!((m_ANT_PATH).Length()!=0) && FileType(t_path)==2){
 									m_ANT_PATH=t_path;
 								}
 							}else{
-								if(t_5==String(L"FLEX_PATH",9)){
+								if(t_4==String(L"FLEX_PATH",9)){
 									if(!((m_FLEX_PATH).Length()!=0) && FileType(t_path)==2){
 										m_FLEX_PATH=t_path;
 									}
 								}else{
-									if(t_5==String(L"MINGW_PATH",10)){
+									if(t_4==String(L"MINGW_PATH",10)){
 										if(!((m_MINGW_PATH).Length()!=0) && FileType(t_path)==2){
 											m_MINGW_PATH=t_path;
 										}
 									}else{
-										if(t_5==String(L"PSM_PATH",8)){
+										if(t_4==String(L"PSM_PATH",8)){
 											if(!((m_PSM_PATH).Length()!=0) && FileType(t_path)==2){
 												m_PSM_PATH=t_path;
 											}
 										}else{
-											if(t_5==String(L"MSBUILD_PATH",12)){
+											if(t_4==String(L"MSBUILD_PATH",12)){
 												if(!((m_MSBUILD_PATH).Length()!=0) && FileType(t_path)==1){
 													m_MSBUILD_PATH=t_path;
 												}
 											}else{
-												if(t_5==String(L"AGK_PATH",8)){
+												if(t_4==String(L"AGK_PATH",8)){
 													if(!((m_AGK_PATH).Length()!=0) && FileType(t_path)==2){
 														m_AGK_PATH=t_path;
 													}
 												}else{
-													if(t_5==String(L"HTML_PLAYER",11)){
+													if(t_4==String(L"HTML_PLAYER",11)){
 														m_HTML_PLAYER=t_rhs;
 													}else{
-														if(t_5==String(L"FLASH_PLAYER",12)){
+														if(t_4==String(L"FLASH_PLAYER",12)){
 															m_FLASH_PLAYER=t_rhs;
 														}else{
 															bbPrint(String(L"Trans: ignoring unrecognized config var: ",41)+t_lhs);
@@ -18710,8 +18711,8 @@ void c_TransCC::p_LoadConfig(){
 			}
 		}
 	}
-	String t_6=HostOS();
-	if(t_6==String(L"winnt",5)){
+	String t_5=HostOS();
+	if(t_5==String(L"winnt",5)){
 		String t_path2=GetEnv(String(L"PATH",4));
 		if((m_ANDROID_PATH).Length()!=0){
 			t_path2=t_path2+(String(L";",1)+m_ANDROID_PATH+String(L"/tools",6));
@@ -18736,7 +18737,7 @@ void c_TransCC::p_LoadConfig(){
 			SetEnv(String(L"JAVA_HOME",9),m_JDK_PATH);
 		}
 	}else{
-		if(t_6==String(L"macos",5)){
+		if(t_5==String(L"macos",5)){
 			String t_path3=GetEnv(String(L"PATH",4));
 			if((m_JDK_PATH).Length()!=0){
 				t_path3=m_JDK_PATH+String(L"/bin:",5)+t_path3;
@@ -18758,7 +18759,7 @@ void c_TransCC::p_LoadConfig(){
 				SetEnv(String(L"JAVA_HOME",9),m_JDK_PATH);
 			}
 		}else{
-			if(t_6==String(L"linux",5)){
+			if(t_5==String(L"linux",5)){
 				String t_path4=GetEnv(String(L"PATH",4));
 				if((m_JDK_PATH).Length()!=0){
 					t_path4=m_JDK_PATH+String(L"/bin:",5)+t_path4;
@@ -20371,6 +20372,8 @@ void c_Builder::p_Make(){
 	bb_config_ENV_TARGET=m_tcc->m_target->m_system;
 	bb_config_ENV_LANG=m_tcc->m_target->m_lang;
 	bb_config_ENV_CUSTOMBUILDSCRIPT=m_tcc->m_target->m_buildscript;
+	bb_config_ENV_PROJECTDIRECTORY=bb_os_ExtractDir(m_tcc->m_opt_srcpath);
+	bb_config_ENV_CERBERUSLIBSDIR=m_tcc->m_cerberusdir+String(L"/libs",5);
 	this->p_Begin();
 	if(!m_tcc->m_opt_check){
 		return;
@@ -20381,6 +20384,8 @@ void c_Builder::p_Make(){
 	bb_config_SetConfigVar2(String(L"TARGET",6),bb_config_ENV_TARGET,false);
 	bb_config_SetConfigVar2(String(L"CONFIG",6),bb_config_ENV_CONFIG,false);
 	bb_config_SetConfigVar2(String(L"SAFEMODE",8),String(bb_config_ENV_SAFEMODE),false);
+	bb_config_SetConfigVar2(String(L"PROJECTDIR",10),bb_config_ENV_PROJECTDIRECTORY,false);
+	bb_config_SetConfigVar2(String(L"CXLIBSDIR",9),bb_config_ENV_CERBERUSLIBSDIR,false);
 	gc_assign(m_app,bb_parser_ParseApp(m_tcc->m_opt_srcpath));
 	bbPrint(String(L"Semanting...",12));
 	if((bb_config_GetConfigVar(String(L"REFLECTION_FILTER",17))).Length()!=0){
@@ -21907,7 +21912,7 @@ void c_StdcppBuilder::p_MakeGcc2(String t_cc_opts,String t_cc_libs,String t_cc_l
 	if(t_outpath==String()){
 		t_outpath=CurrentDir();
 	}else{
-		t_outpath=RealPath(bb_transcc_ExpandEnv(t_outpath));
+		t_outpath=RealPath(t_outpath);
 	}
 	if(t_out==String()){
 		t_out=String(L"main_",5)+HostOS();
@@ -21998,7 +22003,7 @@ void c_StdcppBuilder::p_MakeMsvc2(String t_cc_opts,String t_cc_libs,String t_cc_
 	if(t_outpath==String()){
 		t_outpath=CurrentDir();
 	}else{
-		t_outpath=RealPath(bb_transcc_ExpandEnv(t_outpath));
+		t_outpath=RealPath(t_outpath);
 	}
 	if(t_out==String()){
 		t_out=String(L"main_",5)+HostOS();
@@ -22045,7 +22050,7 @@ void c_StdcppBuilder::p_MakeXcode2(String t_cc_opts,String t_cc_libs,String t_cc
 	if(t_outpath==String()){
 		t_outpath=CurrentDir();
 	}else{
-		t_outpath=RealPath(bb_transcc_ExpandEnv(t_outpath));
+		t_outpath=RealPath(t_outpath);
 	}
 	if(t_out==String()){
 		t_out=String(L"main_",5)+HostOS();
@@ -27457,6 +27462,9 @@ String bb_config_EvalConfigTags(String t_cfg){
 		}
 		String t_key=t_cfg.Slice(t_i+2,t_e);
 		String t_val=bb_config__cfgScope->m_vars->p_Get(t_key);
+		if(t_val==String()){
+			t_val=GetEnv(t_key);
+		}
 		t_cfg=t_cfg.Slice(0,t_i)+t_val+t_cfg.Slice(t_e+1);
 		t_i+=t_val.Length();
 	}while(!(false));
@@ -31888,6 +31896,8 @@ void c_NodeEnumerator2::mark(){
 String bb_config_ENV_HOST;
 String bb_config_ENV_CONFIG;
 String bb_config_ENV_TARGET;
+String bb_config_ENV_PROJECTDIRECTORY;
+String bb_config_ENV_CERBERUSLIBSDIR;
 String bb_os_StripAll(String t_path){
 	return bb_os_StripDir(bb_os_StripExt(t_path));
 }
@@ -36316,45 +36326,6 @@ int bb_builder_GetInfo_GIF(String t_path){
 	}
 	return -1;
 }
-String bb_transcc_ExpandEnv(String t_text){
-	String t_resolved=String();
-	String t_char=String();
-	int t_idx1=0;
-	int t_terminator=0;
-	int t_idx2=0;
-	while(t_idx1<t_text.Length()){
-		t_char=String((Char)((int)t_text[t_idx1]),1);
-		String t_1=t_char;
-		if(t_1==String(L"%",1)){
-			t_terminator=t_text.Find(String(L"%",1),t_idx1+1);
-			t_resolved=t_resolved+GetEnv(t_text.Slice(t_idx1+1,t_terminator));
-			if(t_terminator<0){
-				t_terminator=t_text.Length();
-			}
-			t_idx1+=t_terminator+1-t_idx1;
-		}else{
-			if(t_1==String(L"$",1)){
-				t_terminator=-1;
-				t_idx2=t_idx1;
-				while(t_idx2<t_text.Length() && t_terminator<0){
-					if((int)t_text[t_idx2]==47 || (int)t_text[t_idx2]==58 || (int)t_text[t_idx2]==59){
-						t_terminator=t_idx2;
-					}
-					t_idx2+=1;
-				}
-				if(t_terminator<0){
-					t_terminator=t_text.Length();
-				}
-				t_resolved=t_resolved+GetEnv(t_text.Slice(t_idx1+1,t_terminator));
-				t_idx1+=t_terminator-t_idx1;
-			}else{
-				t_resolved=t_resolved+t_char;
-				t_idx1+=1;
-			}
-		}
-	}
-	return t_resolved;
-}
 int bb_transcc_CreateDirs(String t_path,String t_delim){
 	bbPrint(String(L"Creating output directory structure:\n",37)+t_path);
 	Array<String > t_dirs=t_path.Split(t_delim);
@@ -36369,11 +36340,11 @@ int bb_transcc_CreateDirs(String t_path,String t_delim){
 	while(t_2<t_.Length()){
 		String t_i=t_[t_2];
 		t_2=t_2+1;
-		int t_22=FileType(t_i);
-		if(t_22==2){
+		int t_1=FileType(t_i);
+		if(t_1==2){
 			bbPrint(String(L"Directory already exists:\n",26)+RealPath(t_i));
 		}else{
-			if(t_22==1){
+			if(t_1==1){
 				bb_transcc_Die(String(L"Directory creation error: Path is a regular file. Cannot continue.\n",67)+RealPath(t_i));
 			}else{
 				if((CreateDir(t_i.Trim()))!=0){
@@ -38654,6 +38625,8 @@ int bbInit(){
 	bb_config_ENV_HOST=String();
 	bb_config_ENV_CONFIG=String();
 	bb_config_ENV_TARGET=String();
+	bb_config_ENV_PROJECTDIRECTORY=String();
+	bb_config_ENV_CERBERUSLIBSDIR=String();
 	c_Stack9::m_NIL=0;
 	c_Stack::m_NIL=String();
 	bb_translator__trans=0;

--- a/src/transcc/transcc.cxs
+++ b/src/transcc/transcc.cxs
@@ -12,9 +12,13 @@ Import builders
 	'	DEBUG_TEST: TransCC,Reflection,Mojo,Mojo2,Audio
 		
 	' Change the preprocessor directives to select the example to run for debugging transcc
+	' #DEBUG_TEST_CFG="Release"
+	' #DEBUG_TEST="TransCC"
+	' #DEBUG_TARGET="Desktop"
+	' NOTE: If changes are made to the following, then they should be reset back to the defaults as above to avoid unneccessary commit of this file.
 	#DEBUG_TEST_CFG="Release"
-	#DEBUG_TEST="Audio"
-	#DEBUG_TARGET="HTML"
+	#DEBUG_TEST="TransCC"
+	#DEBUG_TARGET="Desktop"
 	Import debugconf
 	
 	Const VERSION:="2023-10-14 (DEBUG)"
@@ -160,43 +164,45 @@ Function MatchPath:Bool( text:String,pattern:String )
     Return match
 End
 
-Function ExpandEnv:String( text:String )
-	
-	Local resolved:="", char:="", idx1:=0, terminator:=0, idx2:=0
-	While idx1<text.Length
-		char=String.FromChar( text[idx1] )
-		
-		Select char
-		' MS Windows style environment expansion
-		Case "%"
-			terminator=text.Find( "%",idx1+1 )
-			resolved+=GetEnv(text[idx1+1..terminator])
-			If terminator<0 terminator=text.Length
-			idx1+=(terminator+1)-idx1
-		
-		' Unix style environment expansion
-		Case "$"
-			terminator=-1
-			idx2=idx1
-			
-			' Look ahead for one of the known termination characters.
-			While idx2<text.Length And terminator<0
-				If text[idx2]="/"[0] Or text[idx2]=":"[0] Or text[idx2]=";"[0] terminator=idx2
-				idx2+=1
-			Wend
-			If terminator<0 terminator=text.Length
-			resolved+=GetEnv(text[idx1+1..terminator])
-			idx1+=(terminator)-idx1
-			
-		Default
-			resolved+=char
-			idx1+=1
-			
-		End
-	Wend
-	
-	Return resolved
-End
+' NOTE: Scheduled for removal as it increases compile times
+' Use ${KEY} to get environment variables. 
+'Function ExpandEnv:String( text:String )
+'	
+'	Local resolved:="", char:="", idx1:=0, terminator:=0, idx2:=0
+'	While idx1<text.Length
+'		char=String.FromChar( text[idx1] )
+'		
+'		Select char
+'		' MS Windows style environment expansion
+'		Case "%"
+'			terminator=text.Find( "%",idx1+1 )
+'			resolved+=GetEnv(text[idx1+1..terminator])
+'			If terminator<0 terminator=text.Length
+'			idx1+=(terminator+1)-idx1
+'		
+'		' Unix style environment expansion
+'		Case "$"
+'			terminator=-1
+'			idx2=idx1
+'			
+'			' Look ahead for one of the known termination characters.
+'			While idx2<text.Length And terminator<0
+'				If text[idx2]="/"[0] Or text[idx2]=":"[0] Or text[idx2]=";"[0] terminator=idx2
+'				idx2+=1
+'			Wend
+'			If terminator<0 terminator=text.Length
+'			resolved+=GetEnv(text[idx1+1..terminator])
+'			idx1+=(terminator)-idx1
+'			
+'		Default
+'			resolved+=char
+'			idx1+=1
+'			
+'		End
+'	Wend
+'	
+'	Return resolved
+'End
 
 Function CreateDirs( path:String,delim:String="/" )
 	
@@ -283,7 +289,7 @@ Class TransCC
   
     Field _builders:=New StringMap<Builder>
     Field _targets:=New StringMap<Target>
-    Field _libs:String
+    Field _libs:String	' NOTE: Scheduled for removal as it is defined elsewhere
   
     Method Run:Void( args:String[] )
 
@@ -292,7 +298,7 @@ Class TransCC
         Print "TRANS cerberus compiler V"+VERSION
       
         cerberusdir=GetEnv( "CERBERUS_DIR" )
-        _libs=cerberusdir+"/libs/"
+        _libs=cerberusdir+"/libs/"	' NOTE: Scheduled for removal as it is defined elsewhere
 
         SetEnv "CERBERUSDIR",cerberusdir
         SetEnv "MONKEYDIR",cerberusdir 'this is for Jungle compatibility

--- a/src/transcc/transcc_test/cpptool/cpptool.cxs
+++ b/src/transcc/transcc_test/cpptool/cpptool.cxs
@@ -1,17 +1,28 @@
 #If HOST="winnt"
 #CC_OUTPUT_NAME="test_winnt"
-#CC_OUTPUT_PATH="$USERPROFILE/Documents/Cerberus-X"
+#CC_OUTPUT_PATH="${USERPROFILE}/Documents/Cerberus-X"
 #CC_MSIZE="64"
 #CC_USE_MINGW=True
 #Elseif HOST="macos"
 #CC_OUTPUT_NAME="test_macos"
-#CC_OUTPUT_PATH="$HOME/Documents/Cerberus-X"
+#CC_OUTPUT_PATH="${HOME}/Documents/Cerberus-X"
 #Else
 #CC_OUTPUT_NAME="test_linux"
-#CC_OUTPUT_PATH="$HOME/Documents/Cerberus-X"
+#CC_OUTPUT_PATH="${HOME}/Documents/Cerberus-X"
 #Endif
 Import brl.filesystem
 'Import os
+#ENV_TEST=1
+
+#If ENV_TEST=1
+#CERB_TAGS="${CERBERUS_DIR}"
+#CERB_LIB_TAGS="${CXLIBSDIR}"
+#PROJECT_FULL="${CC_OUTPUT_PATH}/${CC_OUTPUT_NAME}"
+#Print "CERB:  "+CERB_TAGS
+#Print "CERB_LIB: "+CERB_LIB_TAGS
+#Print "PROJECT DIR: "+PROJECTDIR
+#Print "PROJECT PATH FULL: "+PROJECT_FULL
+#Endif
 
 Function Main:Int()
 	Print "Hello World!"


### PR DESCRIPTION
Okay. A few changes.
Removed the hacky ExpandEnv function from transcc to parse for environment variables using various tags. It added to the compile time. I've just modified the EvalConfigTags function to check for system variables if the key was not found in the config variables. You can access them just like you would in the config text file e.g. ${CERBERUSDIR}.

I've added two new config variables: PROJECTDIR and CXLIBSDIR. These are not in the documents yet.
CXLIBSDIR points to the Cerberus libraries directory. This may be removed when I get round to doing the the reworking of the glfw and C++ tool code.
PROJECTDIR point to launch source file.

The transcc test file has been update with the above changes. 
@PhilMoe Don't merge this one. Just found a bug that screws up the command line.
Edit: False alarm. It was from part of the test code I was using.
  